### PR TITLE
単体テストを実装(#4)

### DIFF
--- a/lib/team_splitter.py
+++ b/lib/team_splitter.py
@@ -23,6 +23,7 @@ class TeamSplitter:
             return self.DEFAULT_TEAM_SIZE
 
     # 手動でユーザの追加、除外設定を行う場合
+    # TODO: [a, b]のようにコンマ後にスペースがある場合も名前の一部として認識されるので要修正(#20)
     def modify_user_list(self, target_list, message):
         appending_users = []
         removing_users = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 discord.py==1.4.1
 python-dotenv
+pytest
+pytest-mock

--- a/tests/create_mock.py
+++ b/tests/create_mock.py
@@ -1,0 +1,35 @@
+from unittest import mock
+class CreateMock:
+    def user(self, name):
+        attr = {"name":name, "display_name":name, "mention":f"@{name}"}
+        user = mock.Mock()
+        user.configure_mock(**attr)
+        return user
+
+    def users(self, user_count = 10, name_begin = 0):
+        user_list = []
+        for i in range(0,user_count):
+            user_list.append(self.user(f"listuser_{i + name_begin}"))
+        return user_list
+
+    def reaction(self, author, emoji=":rl:"):
+        a = {"author":author}
+        message = mock.Mock()
+        message.configure_mock(**a)
+
+        attr = {"message":message, "emoji":emoji}
+        reaction = mock.Mock()
+        reaction.configure_mock(**attr)
+        return reaction
+
+    def message(self, mes, author=""):
+        attr = {"content":mes, "author":author}
+        res = mock.Mock()
+        res.configure_mock(**attr)
+        return res
+
+    def voice_channel(self, name, members):
+        attr = {"name":name, "members":members}
+        res = mock.Mock()
+        res.configure_mock(**attr)
+        return res

--- a/tests/lib/test_help.py
+++ b/tests/lib/test_help.py
@@ -1,0 +1,24 @@
+import pytest
+from lib.help import Help
+
+@pytest.mark.parametrize("mes, expect", [
+    ("/rl -h"         , True),
+    ("/team -h"       , True),
+    ("/rl"            , None),
+    ("-h"             , None),
+    (""               , None),
+    ("/rl -h /team -h", True)
+])
+def test_is_help(mes, expect):
+    assert Help().is_help(mes) == expect
+
+@pytest.mark.parametrize("mes, expect", [
+    ("/rl -h"         , Help()._rl_help()  ),
+    ("/team -h"       , Help()._team_help()),
+    ("/rl"            , ""                 ),
+    ("-h"             , ""                 ),
+    (""               , ""                 ),
+    ("/rl -h /team -h", Help()._rl_help()  )
+])
+def test_get_help_mes(mes, expect):
+    assert Help().get_help_mes(mes) == expect

--- a/tests/lib/test_reaction_notifier.py
+++ b/tests/lib/test_reaction_notifier.py
@@ -1,0 +1,72 @@
+import pytest
+import re
+from unittest import mock
+from tests.create_mock import CreateMock
+
+from lib.reaction_notifier import ReactionNotifier
+
+poster = CreateMock().user("poster")
+user_list = CreateMock().users()
+@pytest.mark.parametrize("poster, user_list, expect", [
+    (poster      , user_list, user_list + [poster]),
+    (user_list[0], user_list, user_list           ),
+    (poster      , []       , [poster]            ),
+])
+def test_get_unique_users(poster, user_list, expect):
+    assert ReactionNotifier().get_unique_users(poster, user_list) == expect
+
+gathered_users = CreateMock().users(6)
+list_head_reaction = CreateMock().reaction(gathered_users[0])
+author = CreateMock().user("author")
+author_reaction = CreateMock().reaction(author)
+@pytest.mark.parametrize("users, reaction, expect",[
+    (
+        gathered_users,
+        list_head_reaction,
+        ReactionNotifier()._create_gathered_message(list_head_reaction, gathered_users)
+    ),
+    (
+        gathered_users[:6],
+        author_reaction,
+        ReactionNotifier()._create_gathered_message(author_reaction, gathered_users[:6] + [author])
+    ),
+    (
+        gathered_users[:5],
+        list_head_reaction,
+        None
+    ),
+    (
+        [],
+        author_reaction,
+        None
+    )
+])
+
+def test_is_rl_gathered(users, reaction, expect):
+    assert ReactionNotifier().is_rl_gathered(reaction, users) == expect
+
+@pytest.mark.parametrize("reaction, expect", [
+    (CreateMock().reaction("author", emoji = ":rl:"  ), True ),
+    (CreateMock().reaction("author", emoji = ":rlx:" ), False),
+    (CreateMock().reaction("author", emoji = ":rl:x" ), True ),
+    (CreateMock().reaction("author", emoji = ":fill:"), False),
+    (CreateMock().reaction("author", emoji = ""      ), False)
+])
+def test_is_rl_reaction(reaction, expect):
+    result = ReactionNotifier().is_rl_reaction(reaction)
+    assert bool(result) == expect
+
+@pytest.mark.parametrize("reaction, user_names, expect", [
+    (
+        CreateMock().reaction("author", emoji = ":rl:"),
+        CreateMock().users(6),
+        "6人集まりました:rl:\n@listuser_0\n@listuser_1\n@listuser_2\n@listuser_3\n@listuser_4\n@listuser_5\n"
+    ),
+    (
+        CreateMock().reaction("author", emoji = ":rl:"),
+        CreateMock().users(8),
+        "6人集まりました:rl:\n@listuser_0\n@listuser_1\n@listuser_2\n@listuser_3\n@listuser_4\n@listuser_5\n@listuser_6\n@listuser_7\n"
+    ),
+])
+def test_create_gathered_message(reaction, user_names, expect):
+    assert ReactionNotifier()._create_gathered_message(reaction, user_names) == expect

--- a/tests/lib/test_team_splitter.py
+++ b/tests/lib/test_team_splitter.py
@@ -1,0 +1,325 @@
+import pytest
+import re
+from unittest import mock
+from tests.create_mock import CreateMock
+from lib.team_splitter import TeamSplitter
+
+@pytest.mark.parametrize("message, expect", [
+    (CreateMock().message("/team -num 1" ), 1),
+    (CreateMock().message("/team -num 10"), 10),
+    (CreateMock().message("/team -num 1a"), 1),
+    (CreateMock().message("/team-num 3"  ), 3),
+    (CreateMock().message(""             ), TeamSplitter().DEFAULT_TEAM_NUM),
+    (CreateMock().message("/team -num a1"), TeamSplitter().DEFAULT_TEAM_NUM),
+])
+def test_set_team_num(message, expect):
+    assert TeamSplitter().set_team_num(message) == expect
+
+@pytest.mark.parametrize("message, expect", [
+    (CreateMock().message("/team -size 1" ), 1),
+    (CreateMock().message("/team -size 10"), 10),
+    (CreateMock().message("/team -size 1a"), 1),
+    (CreateMock().message("/team-size 3"  ), 3),
+    (CreateMock().message(""              ), TeamSplitter().DEFAULT_TEAM_SIZE),
+    (CreateMock().message("/team -size a1"), TeamSplitter().DEFAULT_TEAM_SIZE),
+])
+def test_set_team_size(message, expect):
+    assert TeamSplitter().set_team_size(message) == expect
+
+@pytest.mark.parametrize("message, user_names, expect", [
+    (
+        CreateMock().message("/team"),
+        ["a", "b", "c", "d", "e"],
+        ["a", "b", "c", "d", "e"]
+    ),
+    (
+        CreateMock().message("/team -user [y,z]"),
+        ["a", "b", "c", "d", "e"],
+        ["a", "b", "c", "d", "e", "y", "z"]
+    ),
+    (
+        CreateMock().message("/team -user [-a,-b]"),
+        ["a", "b", "c", "d", "e"],
+        ["c", "d", "e"]
+    ),
+    (
+        CreateMock().message("/team -user [z,-a]"),
+        ["a", "b", "c", "d", "e"],
+        ["b", "c", "d", "e", "z"]
+    ),
+    (
+        CreateMock().message("/team -user [-a,z]"),
+        ["a", "b", "c", "d", "e"],
+        ["b", "c", "d", "e", "z"]
+    ),
+    (
+        CreateMock().message("/team -user [z,-z]"),
+        ["a", "b", "c", "d", "e"],
+        ["a", "b", "c", "d", "e"]
+    ),
+    (
+        CreateMock().message("/team -user [-z,z]"),
+        ["a", "b", "c", "d", "e"],
+        ["a", "b", "c", "d", "e"]
+    ),
+    (
+        CreateMock().message("/team -user"),
+        ["a", "b", "c", "d", "e"],
+        ["a", "b", "c", "d", "e"]
+    ),
+    (
+        CreateMock().message("/team -user []"),
+        ["a", "b", "c", "d", "e"],
+        ["a", "b", "c", "d", "e"]
+    ),
+])
+def test_modify_user_list(message, user_names, expect):
+    # modify_user_listは内部でリストをsetに変換しているので順番が入れ替わる
+    assert set(TeamSplitter().modify_user_list(user_names, message)) == set(expect)
+
+splitted_users = CreateMock().users(7)
+@pytest.mark.parametrize("users, team_num, expect", [
+    (
+        splitted_users[:6],
+        2,
+        [
+            [splitted_users[0], splitted_users[2], splitted_users[4]],
+            [splitted_users[1], splitted_users[3], splitted_users[5]]
+        ]
+    ),
+    (
+        splitted_users[:7],
+        2,
+        [
+            [splitted_users[0], splitted_users[2], splitted_users[4], splitted_users[6]],
+            [splitted_users[1], splitted_users[3], splitted_users[5]]
+        ]
+    ),
+    (
+        splitted_users[:6],
+        10,
+        [[splitted_users[0]], [splitted_users[1]], [splitted_users[2]], [splitted_users[3]], [splitted_users[4]], [splitted_users[5]]]
+    ),
+    (
+        [],
+        2,
+        []
+    )
+])
+def test_split_list(users, team_num, expect):
+    assert TeamSplitter().split_list(users, team_num) == expect
+
+lol_users = CreateMock().users(12)
+@pytest.mark.parametrize("users, expect", [
+    (
+        lol_users[:10],
+        [ 
+            lol_users[0:5 ],
+            lol_users[5:10],
+            []
+        ]
+    ),
+    (
+        lol_users[:12],
+        [ 
+            lol_users[0:5  ],
+            lol_users[5:10 ],
+            lol_users[10:12],
+        ]
+    ),
+    (
+        lol_users[:8],
+        [ 
+            lol_users[0:5],
+            lol_users[5:8],
+            []
+        ]
+    ),
+    (
+        [],
+        [ [], [], [] ]
+    )
+])
+def test_lol_team(users, expect):
+    assert TeamSplitter().make_lol_team(users) == expect
+
+@pytest.mark.parametrize("message, expect", [
+    ("/team"         ,True ),
+    ("/team -option" ,True ),
+    ("/teams"        ,True ),
+    ("team"          ,False),
+    ("x/team"        ,False),
+    ("/tea m"        ,False),
+    (" /team"        ,False),
+])
+def test_is_team_command(message, expect):
+    assert TeamSplitter().is_team_command(message) == expect
+
+def rand_return_value(l,len):
+    return l
+
+def modify_user_list_mock(names, message):
+    return names
+
+@pytest.mark.parametrize("vc, message, expect", [
+    (
+        None,
+        CreateMock().message("/team"),
+        "error:投稿者はボイスチャンネルに接続していません"
+    ),
+    (
+        CreateMock().voice_channel("VC_channel", CreateMock().users(6)),
+        CreateMock().message("/team"),
+        "----------|teamNum = 2|----------\n"
+        "Team 1:\n"
+        ":bust_in_silhouette: listuser_0\n"
+        ":bust_in_silhouette: listuser_2\n"
+        ":bust_in_silhouette: listuser_4\n"
+        "Team 2:\n"
+        ":bust_in_silhouette: listuser_1\n"
+        ":bust_in_silhouette: listuser_3\n"
+        ":bust_in_silhouette: listuser_5\n"
+    ),
+    (
+        CreateMock().voice_channel("VC_channel", CreateMock().users(5)),
+        CreateMock().message("/team"),
+        "----------|teamNum = 2|----------\n"
+        "Team 1:\n"
+        ":bust_in_silhouette: listuser_0\n"
+        ":bust_in_silhouette: listuser_2\n"
+        ":bust_in_silhouette: listuser_4\n"
+        "Team 2:\n"
+        ":bust_in_silhouette: listuser_1\n"
+        ":bust_in_silhouette: listuser_3\n"
+    ),
+    (
+        CreateMock().voice_channel("VC_channel", CreateMock().users(1)),
+        CreateMock().message("/team"),
+        "----------|teamNum = 2|----------\n"
+        "Team 1:\n"
+        ":bust_in_silhouette: listuser_0\n"
+    ),
+    (
+        CreateMock().voice_channel("VC_channel", CreateMock().users(9)),
+        CreateMock().message("/team -lol"),
+        "error: 人数が10人未満です。"
+    ),
+
+])
+def test_create_teams(mocker, vc, message, expect):
+    mocker.patch("lib.util.Util.GetAuthorVChannel", return_value=vc)
+    mocker.patch("random.sample", side_effect=rand_return_value)
+    # modify_user_listは内部でsetを使っているので、利用すると順番が入れ替わる
+    mocker.patch("lib.team_splitter.TeamSplitter.modify_user_list", side_effect=modify_user_list_mock)
+    assert TeamSplitter().create_teams(mock.Mock(), message) == expect
+
+@pytest.mark.parametrize("team_num, team_size, expect", [
+    (2, 50, "----------|teamNum = 2|----------\n"),  
+    (2, 2,  "----------|teamNum = 2, TeamSize = 2|----------\n"),
+    (4, 50, "----------|teamNum = 4|----------\n"),
+    (4, 2,  "----------|teamNum = 4, TeamSize = 2|----------\n"),
+])
+def test_create_team_headder(team_num, team_size, expect):
+    assert TeamSplitter().create_team_headder(team_num, team_size) == expect
+
+normal_result_users = ["listuser_" + str(i) for i in range(0,6)]
+@pytest.mark.parametrize("teams, expect", [
+    (
+        [
+            normal_result_users[0:3],
+            normal_result_users[3:6]
+        ],
+        "Team 1:\n"
+        ":bust_in_silhouette: listuser_0\n"
+        ":bust_in_silhouette: listuser_1\n"
+        ":bust_in_silhouette: listuser_2\n"
+        "Team 2:\n"
+        ":bust_in_silhouette: listuser_3\n"
+        ":bust_in_silhouette: listuser_4\n"
+        ":bust_in_silhouette: listuser_5\n"
+    ),
+    (
+        [
+            normal_result_users[0:2],
+            normal_result_users[2:4],
+            normal_result_users[4:6],
+        ],
+        "Team 1:\n"
+        ":bust_in_silhouette: listuser_0\n"
+        ":bust_in_silhouette: listuser_1\n"
+        "Team 2:\n"
+        ":bust_in_silhouette: listuser_2\n"
+        ":bust_in_silhouette: listuser_3\n"
+        "Team 3:\n"
+        ":bust_in_silhouette: listuser_4\n"
+        ":bust_in_silhouette: listuser_5\n"
+    ),
+    (
+        [ [] ],
+        "Team 1:\n"
+    ),
+    (
+        [
+            normal_result_users[0:2],
+            []
+        ],
+        "Team 1:\n"
+        ":bust_in_silhouette: listuser_0\n"
+        ":bust_in_silhouette: listuser_1\n"
+        "Team 2:\n"
+    )
+])
+def test_normal_result(teams, expect):
+    assert TeamSplitter().normal_result(teams) == expect
+
+lol_result_users = ["listuser_" + str(i) for i in range(0,12)]
+@pytest.mark.parametrize("teams, expect", [
+    (
+        [
+            lol_result_users[0:5],
+            lol_result_users[5:10]
+        ],
+        ":blue_car:Blue Side:blue_car:\n"
+        "  :man_raising_hand: listuser_0\n"
+        "  :man_raising_hand: listuser_1\n"
+        "  :man_raising_hand: listuser_2\n"
+        "  :man_raising_hand: listuser_3\n"
+        "  :man_raising_hand: listuser_4\n"
+        ":red_car: Red Side:red_car: \n"
+        "  :person_raising_hand: listuser_5\n"
+        "  :person_raising_hand: listuser_6\n"
+        "  :person_raising_hand: listuser_7\n"
+        "  :person_raising_hand: listuser_8\n"
+        "  :person_raising_hand: listuser_9\n"
+    ),
+    (
+        [
+            lol_result_users[0:5],
+            lol_result_users[5:10],
+            lol_result_users[10:12],
+        ],
+        ":blue_car:Blue Side:blue_car:\n"
+        "  :man_raising_hand: listuser_0\n"
+        "  :man_raising_hand: listuser_1\n"
+        "  :man_raising_hand: listuser_2\n"
+        "  :man_raising_hand: listuser_3\n"
+        "  :man_raising_hand: listuser_4\n"
+        ":red_car: Red Side:red_car: \n"
+        "  :person_raising_hand: listuser_5\n"
+        "  :person_raising_hand: listuser_6\n"
+        "  :person_raising_hand: listuser_7\n"
+        "  :person_raising_hand: listuser_8\n"
+        "  :person_raising_hand: listuser_9\n"
+        "抽選漏れ\n"
+        "  :no_entry_sign: listuser_10\n"
+        "  :no_entry_sign: listuser_11\n"
+    ),
+    (
+        [
+            []
+        ],
+        ":blue_car:Blue Side:blue_car:\n"
+    )
+])
+def test_lol_result(teams, expect):
+    assert TeamSplitter().lol_result(teams) == expect


### PR DESCRIPTION
pytestを用いた単体テストを作成
* randomBot.py(main)はイベントルーム処理が主なので今回は対応していない。
  * 対応する場合、非同期処理用のテストフレームワークの導入が必要
* テストフレームワークの導入が主目的であり、リファクタリングは全体の構成の見直し後に行う

close #4